### PR TITLE
UseBridgeIPasGW and dont require subnet and other tweaks

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -100,8 +100,16 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return errors.New("IPAM plugin returned missing IPv4 config")
 	}
 
-	if result.IP4.Gateway == nil && n.IsGW {
-		result.IP4.Gateway = calcGatewayIP(&result.IP4.IP)
+	if n.IsGW {
+		if n.UseBridgeIPAsGW {
+			bridgeIP, err := getBridgeIP(br)
+			if err != nil {
+				return err
+			}
+			result.IP4.Gateway = bridgeIP
+		} else if result.IP4.Gateway == nil {
+			result.IP4.Gateway = calcGatewayIP(&result.IP4.IP)
+		}
 	}
 
 	if err := netns.Do(func(_ ns.NetNS) error {

--- a/bridge.go
+++ b/bridge.go
@@ -89,6 +89,22 @@ func cmdAdd(args *skel.CmdArgs) error {
 		logrus.Infof("rancher-cni-bridge: container already has interface: %v, no worries", args.IfName)
 	}
 
+	if err := netns.Do(func(_ ns.NetNS) error {
+		if nArgs.MACAddress != "" {
+			err := setInterfaceMacAddress(args.IfName, string(nArgs.MACAddress))
+			if err != nil {
+				logrus.Errorf("error setting MAC address: %v", err)
+				return fmt.Errorf("Couldn't set the MAC Address of the interface: %v", err)
+			}
+			logrus.Debugf("rancher-cni-bridge: have set the %v interface %v MAC address: %v", args.ContainerID, args.IfName, nArgs.MACAddress)
+		} else {
+			logrus.Infof("rancher-cni-bridge: no MAC address specified to set for container: %v", args.ContainerID)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	// run the IPAM plugin and get back the config to apply
 	result, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
 	if err != nil {
@@ -113,17 +129,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if err := netns.Do(func(_ ns.NetNS) error {
-		if nArgs.MACAddress != "" {
-			err := setInterfaceMacAddress(args.IfName, string(nArgs.MACAddress))
-			if err != nil {
-				logrus.Errorf("error setting MAC address: %v", err)
-				return fmt.Errorf("couldn't set the MAC Address of the interface: %v", err)
-			}
-			logrus.Debugf("rancher-cni-bridge: have set the %v interface %v MAC address: %v", args.ContainerID, args.IfName, nArgs.MACAddress)
-		} else {
-			logrus.Infof("rancher-cni-bridge: no MAC address specified to set for container: %v", args.ContainerID)
-		}
-
 		overHeadToUse := 0
 		if nArgs.LinkMTUOverhead != "" {
 			overHeadToUse, err = strconv.Atoi(string(nArgs.LinkMTUOverhead))

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type NetConf struct {
 	BrName          string `json:"bridge"`
 	BrSubnet        string `json:"bridgeSubnet"`
 	BrIP            string `json:"bridgeIP"`
+	UseBridgeIPAsGW bool   `json:"useBridgeIPAsGateway"`
 	LogToFile       string `json:"logToFile"`
 	IsDebugLevel    string `json:"isDebugLevel"`
 	IsGW            bool   `json:"isGateway"`


### PR DESCRIPTION
Add a new config parameter: useBridgeIPasGW. When this is set and IsGW
is set, instead of using the gateway returned by the IPAM plugin or
guessing it based off of the subnet of the IP returned by the IPAM
plugin, use the bridge's existing IP.

Don't make subnet required. It is used to add an IP to the bridge, but
in some usecases, we don't want to supply a subnet and we expect the
bridge to already have an IP address. So, by making subnet optional,
the plugin will not add an IP to the bridge.

Move the setting of mac address to before calling IPAM, as DHCP IPAM needs it to be set to function properly.