### PR TITLE
Rename binary to rancher-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ based on the upstream CNI bridge plugin with customizations on top.
 
 ## Running
 
-The `rancher-cni-bridge` plugin binary needs to be placed
+The `rancher-bridge` plugin binary needs to be placed
 inside `/opt/cni/bin` directory and the necessary configuration
 file needs to be placed inside `/etc/cni/net.d` directory.
 

--- a/scripts/build
+++ b/scripts/build
@@ -6,4 +6,4 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-go build -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" -o bin/rancher-cni-bridge
+go build -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" -o bin/rancher-bridge

--- a/scripts/package
+++ b/scripts/package
@@ -8,7 +8,7 @@ SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 cd $(dirname $0)/..
-if [ ! -e bin/rancher-cni-bridge ]; then
+if [ ! -e bin/rancher-bridge ]; then
     ./scripts/build
 fi
 


### PR DESCRIPTION
Because the projects that use this just rename it to that, so why not
cut out the middle man?